### PR TITLE
Add UI-based properties for Network and Space

### DIFF
--- a/Ontology/Willow/Collection/Network/Network.json
+++ b/Ontology/Willow/Collection/Network/Network.json
@@ -26,6 +26,15 @@
     },
     {
       "@type": "Property",
+      "name": "webMapId",
+      "displayName": {
+        "en": "Web Map ID"
+      },
+      "description": "This defines an ArcGIS-specific web map ID.",
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
       "name": "unitOfMeasurement",
       "displayName": {
         "en": "Unit of Measurement"

--- a/Ontology/Willow/Collection/Network/Network.json
+++ b/Ontology/Willow/Collection/Network/Network.json
@@ -4,7 +4,7 @@
   "displayName": {
     "en": "Network"
   },
-  "extends" : [
+  "extends": [
     "dtmi:com:willowinc:rail:Collection;1"
   ],
   "contents": [
@@ -15,6 +15,23 @@
         "en": "Time Zone"
       },
       "schema": "dtmi:com:willowinc:rail:TimeZone;1"
+    },
+    {
+      "@type": "Component",
+      "name": "mapOption",
+      "displayName": {
+        "en": "Map Option"
+      },
+      "schema": "dtmi:com:willowinc:rail:MapOption;1"
+    },
+    {
+      "@type": "Property",
+      "name": "unitOfMeasurement",
+      "displayName": {
+        "en": "Unit of Measurement"
+      },
+      "description": "This defines whether a network uses the 'metric' or 'imperial' measurement systems.",
+      "schema": "string"
     }
   ],
   "@context": "dtmi:dtdl:context;2"

--- a/Ontology/Willow/Component/MapOption.json
+++ b/Ontology/Willow/Component/MapOption.json
@@ -1,0 +1,51 @@
+{
+    "@id": "dtmi:com:willowinc:rail:MapOption;1",
+    "@type": "Interface",
+    "displayName": {
+        "en": "Map Option"
+    },
+    "description": {
+        "en": "This assigns a default 'fly to' coordinate (longitude, latitude, zoom, pitch, bearing) for the map view."
+    },
+    "extends": [
+        "dtmi:com:willowinc:rail:Component;1"
+    ],
+    "contents": [
+        {
+            "@type": "Property",
+            "name": "centerLongitude",
+            "displayName": "Center Longitude",
+            "writable": true,
+            "schema": "float"
+        },
+        {
+            "@type": "Property",
+            "name": "centerLatitude",
+            "displayName": "Center Latitude",
+            "writable": true,
+            "schema": "float"
+        },
+        {
+            "@type": "Property",
+            "name": "zoom",
+            "displayName": "Zoom",
+            "writable": true,
+            "schema": "float"
+        },
+        {
+            "@type": "Property",
+            "name": "pitch",
+            "displayName": "Pitch",
+            "writable": true,
+            "schema": "float"
+        },
+        {
+            "@type": "Property",
+            "name": "bearing",
+            "displayName": "Bearing",
+            "writable": true,
+            "schema": "float"
+        }
+    ],
+    "@context": "dtmi:dtdl:context;2"
+}

--- a/Ontology/Willow/Space/Space.json
+++ b/Ontology/Willow/Space/Space.json
@@ -7,9 +7,7 @@
   "description": {
     "en": "A contiguous part of the physical world that has a 3D spatial extent and that contains or can contain sub-spaces. E.g., a Region can contain many pieces of Land, which in turn can contain many Buildings."
   },
-  "extends" : [
-
-  ],
+  "extends": [],
   "contents": [
     {
       "@type": "Relationship",
@@ -221,6 +219,14 @@
         "en": "Time Zone"
       },
       "schema": "dtmi:com:willowinc:rail:TimeZone;1"
+    },
+    {
+      "@type": "Component",
+      "name": "mapOption",
+      "displayName": {
+        "en": "Map Option"
+      },
+      "schema": "dtmi:com:willowinc:rail:MapOption;1"
     }
   ],
   "@context": "dtmi:dtdl:context;2"


### PR DESCRIPTION
This adds the following properties into Network:
- MapOption: a new component that's used to "fly" into the correct coordinates on the map.
- Unit of Measurement: defines whether metric or imperial systems are being used by a customer
- Web Map ID: defines the map ID that will be loaded by a frontend

The MapOption component is also added to Space.