### PR TITLE
Add UI Properties

### DIFF
--- a/Ontology/Willow/Agent/Agent.json
+++ b/Ontology/Willow/Agent/Agent.json
@@ -135,6 +135,33 @@
           }
         }
       }
+    },
+    {
+      "@type": "Property",
+      "name": "uiProperties",
+      "displayName": {
+        "en": "UI Properties"
+      },
+      "description": {
+        "en": "A set of properties for user interface components to leverage when retreiving the twin for functionality such as sorting, coloring, and placement."
+      },
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "uiComponentName",
+          "description": {
+            "en": "The name of a user interface component for which properties are desired to be set (i.e. ArcGISWebMap, TimeSeriesViewer)."
+          },
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "uiComponentProperties",
+          "description": {
+            "en": "The properties or settings stored as a JSON string for the user interface to deserialize (i.e. {\"zoom\": 90, \"center\": [10, 40]})."
+          },
+          "schema": "string"
+        }
+      }
     }
   ],
   "@context": "dtmi:dtdl:context;2"

--- a/Ontology/Willow/Asset/Asset.json
+++ b/Ontology/Willow/Asset/Asset.json
@@ -223,6 +223,33 @@
     },
     {
       "@type": "Property",
+      "name": "uiProperties",
+      "displayName": {
+        "en": "UI Properties"
+      },
+      "description": {
+        "en": "A set of properties for user interface components to leverage when retreiving the twin for functionality such as sorting, coloring, and placement."
+      },
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "uiComponentName",
+          "description": {
+            "en": "The name of a user interface component for which properties are desired to be set (i.e. ArcGISWebMap, TimeSeriesViewer)."
+          },
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "uiComponentProperties",
+          "description": {
+            "en": "The properties or settings stored as a JSON string for the user interface to deserialize (i.e. {\"zoom\": 90, \"center\": [10, 40]})."
+          },
+          "schema": "string"
+        }
+      }
+    },
+    {
+      "@type": "Property",
       "displayName": {
         "en": "commission date"
       },

--- a/Ontology/Willow/Capability/Capability.json
+++ b/Ontology/Willow/Capability/Capability.json
@@ -145,6 +145,33 @@
     },
     {
       "@type": "Property",
+      "name": "uiProperties",
+      "displayName": {
+        "en": "UI Properties"
+      },
+      "description": {
+        "en": "A set of properties for user interface components to leverage when retreiving the twin for functionality such as sorting, coloring, and placement."
+      },
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "uiComponentName",
+          "description": {
+            "en": "The name of a user interface component for which properties are desired to be set (i.e. ArcGISWebMap, TimeSeriesViewer)."
+          },
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "uiComponentProperties",
+          "description": {
+            "en": "The properties or settings stored as a JSON string for the user interface to deserialize (i.e. {\"zoom\": 90, \"center\": [10, 40]})."
+          },
+          "schema": "string"
+        }
+      }
+    },
+    {
+      "@type": "Property",
       "name": "connectorID",
       "displayName": {
         "en": "Connector ID"

--- a/Ontology/Willow/Collection/Collection.json
+++ b/Ontology/Willow/Collection/Collection.json
@@ -133,6 +133,33 @@
           }
         }
       }
+    },
+    {
+      "@type": "Property",
+      "name": "uiProperties",
+      "displayName": {
+        "en": "UI Properties"
+      },
+      "description": {
+        "en": "A set of properties for user interface components to leverage when retreiving the twin for functionality such as sorting, coloring, and placement."
+      },
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "uiComponentName",
+          "description": {
+            "en": "The name of a user interface component for which properties are desired to be set (i.e. ArcGISWebMap, TimeSeriesViewer)."
+          },
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "uiComponentProperties",
+          "description": {
+            "en": "The properties or settings stored as a JSON string for the user interface to deserialize (i.e. {\"zoom\": 90, \"center\": [10, 40]})."
+          },
+          "schema": "string"
+        }
+      }
     }
   ],
   "@context": "dtmi:dtdl:context;2"

--- a/Ontology/Willow/Document/Document.json
+++ b/Ontology/Willow/Document/Document.json
@@ -132,6 +132,33 @@
           }
         }
       }
+    },
+    {
+      "@type": "Property",
+      "name": "uiProperties",
+      "displayName": {
+        "en": "UI Properties"
+      },
+      "description": {
+        "en": "A set of properties for user interface components to leverage when retreiving the twin for functionality such as sorting, coloring, and placement."
+      },
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "uiComponentName",
+          "description": {
+            "en": "The name of a user interface component for which properties are desired to be set (i.e. ArcGISWebMap, TimeSeriesViewer)."
+          },
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "uiComponentProperties",
+          "description": {
+            "en": "The properties or settings stored as a JSON string for the user interface to deserialize (i.e. {\"zoom\": 90, \"center\": [10, 40]})."
+          },
+          "schema": "string"
+        }
+      }
     }
   ],
   "@context": "dtmi:dtdl:context;2"

--- a/Ontology/Willow/Event/Event.json
+++ b/Ontology/Willow/Event/Event.json
@@ -130,6 +130,33 @@
     },
     {
       "@type": "Property",
+      "name": "uiProperties",
+      "displayName": {
+        "en": "UI Properties"
+      },
+      "description": {
+        "en": "A set of properties for user interface components to leverage when retreiving the twin for functionality such as sorting, coloring, and placement."
+      },
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "uiComponentName",
+          "description": {
+            "en": "The name of a user interface component for which properties are desired to be set (i.e. ArcGISWebMap, TimeSeriesViewer)."
+          },
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "uiComponentProperties",
+          "description": {
+            "en": "The properties or settings stored as a JSON string for the user interface to deserialize (i.e. {\"zoom\": 90, \"center\": [10, 40]})."
+          },
+          "schema": "string"
+        }
+      }
+    },
+    {
+      "@type": "Property",
       "name": "active",
       "displayName": {
         "en": "Active"

--- a/Ontology/Willow/Space/Space.json
+++ b/Ontology/Willow/Space/Space.json
@@ -207,6 +207,33 @@
       }
     },
     {
+      "@type": "Property",
+      "name": "uiProperties",
+      "displayName": {
+        "en": "UI Properties"
+      },
+      "description": {
+        "en": "A set of properties for user interface components to leverage when retreiving the twin for functionality such as sorting, coloring, and placement."
+      },
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "uiComponentName",
+          "description": {
+            "en": "The name of a user interface component for which properties are desired to be set (i.e. ArcGISWebMap, TimeSeriesViewer)."
+          },
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "uiComponentProperties",
+          "description": {
+            "en": "The properties or settings stored as a JSON string for the user interface to deserialize (i.e. {\"zoom\": 90, \"center\": [10, 40]})."
+          },
+          "schema": "string"
+        }
+      }
+    },
+    {
       "@type": "Component",
       "name": "area",
       "displayName": {

--- a/Ontology/Willow/Structure/Structure.json
+++ b/Ontology/Willow/Structure/Structure.json
@@ -215,6 +215,33 @@
     },
     {
       "@type": "Property",
+      "name": "uiProperties",
+      "displayName": {
+        "en": "UI Properties"
+      },
+      "description": {
+        "en": "A set of properties for user interface components to leverage when retreiving the twin for functionality such as sorting, coloring, and placement."
+      },
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "uiComponentName",
+          "description": {
+            "en": "The name of a user interface component for which properties are desired to be set (i.e. ArcGISWebMap, TimeSeriesViewer)."
+          },
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "uiComponentProperties",
+          "description": {
+            "en": "The properties or settings stored as a JSON string for the user interface to deserialize (i.e. {\"zoom\": 90, \"center\": [10, 40]})."
+          },
+          "schema": "string"
+        }
+      }
+    },
+    {
+      "@type": "Property",
       "displayName": {
         "en": "commission date"
       },


### PR DESCRIPTION
A property bag to be used by user interface components for storing and retrieving settings in the context of a twin.