### PR TITLE
Add application settings

### DIFF
--- a/Ontology/Willow/Agent/Agent.json
+++ b/Ontology/Willow/Agent/Agent.json
@@ -27,6 +27,17 @@
       "target": "dtmi:com:willowinc:rail:Document;1"
     },
     {
+      "@type": "Relationship",
+      "name": "hasSettings",
+      "displayName": {
+        "en": "has settings"
+      },
+      "description": {
+        "en": "Used to extend a twin's base properties with settings that can be used by applications or people to create functionality and experiences in the context of the twin."
+      },
+      "target": "dtmi:com:willowinc:rail:Settings;1"
+    },
+    {
       "@type": "Property",
       "name": "networkId",
       "displayName": {

--- a/Ontology/Willow/Asset/Asset.json
+++ b/Ontology/Willow/Asset/Asset.json
@@ -53,6 +53,17 @@
     },
     {
       "@type": "Relationship",
+      "name": "hasSettings",
+      "displayName": {
+        "en": "has settings"
+      },
+      "description": {
+        "en": "Used to extend a twin's base properties with settings that can be used by applications or people to create functionality and experiences in the context of the twin."
+      },
+      "target": "dtmi:com:willowinc:rail:Settings;1"
+    },
+    {
+      "@type": "Relationship",
       "name": "serviceResponsibility",
       "displayName": {
         "en": "Service Responsibilitly"

--- a/Ontology/Willow/Capability/Capability.json
+++ b/Ontology/Willow/Capability/Capability.json
@@ -10,6 +10,17 @@
   "contents": [
     {
       "@type": "Relationship",
+      "name": "hasSettings",
+      "displayName": {
+        "en": "has settings"
+      },
+      "description": {
+        "en": "Used to extend a twin's base properties with settings that can be used by applications or people to create functionality and experiences in the context of the twin."
+      },
+      "target": "dtmi:com:willowinc:rail:Settings;1"
+    },
+    {
+      "@type": "Relationship",
       "description": {
         "en": "The entity (Asset, Space, LogicalDevice, etc.) that has this Capability. Inverse of: hasCapability"
       },

--- a/Ontology/Willow/Collection/Collection.json
+++ b/Ontology/Willow/Collection/Collection.json
@@ -18,6 +18,17 @@
     },
     {
       "@type": "Relationship",
+      "name": "hasSettings",
+      "displayName": {
+        "en": "has settings"
+      },
+      "description": {
+        "en": "Used to extend a twin's base properties with settings that can be used by applications or people to create functionality and experiences in the context of the twin."
+      },
+      "target": "dtmi:com:willowinc:rail:Settings;1"
+    },
+    {
+      "@type": "Relationship",
       "name": "includedIn",
       "displayName": {
         "en": "included in"

--- a/Ontology/Willow/Document/Document.json
+++ b/Ontology/Willow/Document/Document.json
@@ -10,6 +10,17 @@
   "contents": [
     {
       "@type": "Relationship",
+      "name": "hasSettings",
+      "displayName": {
+        "en": "has settings"
+      },
+      "description": {
+        "en": "Used to extend a twin's base properties with settings that can be used by applications or people to create functionality and experiences in the context of the twin."
+      },
+      "target": "dtmi:com:willowinc:rail:Settings;1"
+    },
+    {
+      "@type": "Relationship",
       "name": "isDocumentOf",
       "displayName": {
         "en": "is document of"

--- a/Ontology/Willow/Event/Event.json
+++ b/Ontology/Willow/Event/Event.json
@@ -10,6 +10,17 @@
   "contents": [
     {
       "@type": "Relationship",
+      "name": "hasSettings",
+      "displayName": {
+        "en": "has settings"
+      },
+      "description": {
+        "en": "Used to extend a twin's base properties with settings that can be used by applications or people to create functionality and experiences in the context of the twin."
+      },
+      "target": "dtmi:com:willowinc:rail:Settings;1"
+    },
+    {
+      "@type": "Relationship",
       "description": {
         "en": "The entity responsible for generating or producing the event."
       },

--- a/Ontology/Willow/Network Element/NetworkElement.json
+++ b/Ontology/Willow/Network Element/NetworkElement.json
@@ -10,6 +10,17 @@
   "contents": [
     {
       "@type": "Relationship",
+      "name": "hasSettings",
+      "displayName": {
+        "en": "has settings"
+      },
+      "description": {
+        "en": "Used to extend a twin's base properties with settings that can be used by applications or people to create functionality and experiences in the context of the twin."
+      },
+      "target": "dtmi:com:willowinc:rail:Settings;1"
+    },
+    {
+      "@type": "Relationship",
       "description": {
         "en": "Indicates that an entity is included in some Collection, e.g., a Building is included in a RealEstate, or a Room is included in an Apartment. Inverse of: includes"
       },

--- a/Ontology/Willow/Settings/ApplicationSettings.json
+++ b/Ontology/Willow/Settings/ApplicationSettings.json
@@ -1,0 +1,55 @@
+{
+  "@id": "dtmi:com:willowinc:rail:ApplicationSettings;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Application Settings"
+  },
+  "description": {
+    "en": "Settings or properties used by an application for its functionality."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:rail:Settings;1"
+  ],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "applicationName",
+      "displayName": {
+        "en": "Application Name"
+      },
+      "description": {
+        "en": "The name of the application which is storing and retreiving the settings for its functionality. This is used to filter all the collection of all application settings."
+      },
+      "writable": true,
+      "schema": "string"
+    },
+    {
+      "@type": "Property",
+      "name": "uiSettings",
+      "displayName": {
+        "en": "UI Settings"
+      },
+      "description": {
+        "en": "A collection of settings related to a twin for user interface components to leverage for functionality such as sorting, coloring, and placement."
+      },
+      "schema": {
+        "@type": "Map",
+        "mapKey": {
+          "name": "uiComponentName",
+          "description": {
+            "en": "The name of a user interface component for which properties are desired to be set (i.e. ArcGISWebMap, TimeSeriesViewer)."
+          },
+          "schema": "string"
+        },
+        "mapValue": {
+          "name": "uiComponentSettings",
+          "description": {
+            "en": "The settings or properties stored as a JSON string for the user interface to deserialize (i.e. {\"zoom\": 90, \"center\": [10, 40]})."
+          },
+          "schema": "string"
+        }
+      }
+    }
+  ],
+  "@context": "dtmi:dtdl:context;2"
+}

--- a/Ontology/Willow/Settings/Settings.json
+++ b/Ontology/Willow/Settings/Settings.json
@@ -1,0 +1,17 @@
+{
+  "@id": "dtmi:com:willowinc:rail:Settings;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Settings"
+  },
+  "description": {
+    "en": "An abstract superclass for settings or properties that extend a twin's base properties."
+  },
+  "extends" : [
+
+  ],
+  "contents": [
+
+  ],
+  "@context": "dtmi:dtdl:context;2"
+}

--- a/Ontology/Willow/Space/Space.json
+++ b/Ontology/Willow/Space/Space.json
@@ -97,6 +97,17 @@
       "target": "dtmi:com:willowinc:rail:Document;1"
     },
     {
+      "@type": "Relationship",
+      "name": "hasSettings",
+      "displayName": {
+        "en": "has settings"
+      },
+      "description": {
+        "en": "Used to extend a twin's base properties with settings that can be used by applications or people to create functionality and experiences in the context of the twin."
+      },
+      "target": "dtmi:com:willowinc:rail:Settings;1"
+    },
+    {
       "@type": "Property",
       "name": "networkId",
       "displayName": {

--- a/Ontology/Willow/Structure/Structure.json
+++ b/Ontology/Willow/Structure/Structure.json
@@ -45,6 +45,17 @@
     },
     {
       "@type": "Relationship",
+      "name": "hasSettings",
+      "displayName": {
+        "en": "has settings"
+      },
+      "description": {
+        "en": "Used to extend a twin's base properties with settings that can be used by applications or people to create functionality and experiences in the context of the twin."
+      },
+      "target": "dtmi:com:willowinc:rail:Settings;1"
+    },
+    {
+      "@type": "Relationship",
       "name": "serviceResponsibility",
       "displayName": {
         "en": "Service Responsibilitly"


### PR DESCRIPTION
A new DTDL model which enables having app settings related to twins. App Settings are stored in a separate twin from the primary twin itself to decouple read/write on the primary twin or settings.