### PR TITLE
Align asset and structure properties

### DIFF
--- a/Ontology/Willow/Asset/Asset.json
+++ b/Ontology/Willow/Asset/Asset.json
@@ -273,11 +273,56 @@
     {
       "@type": "Property",
       "displayName": {
+        "en": "IP address"
+      },
+      "name": "IPAddress",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "MAC address"
+      },
+      "name": "MACAddress",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "model number"
+      },
+      "name": "modelNumber",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
         "en": "physical tag number"
       },
       "name": "physicalTagNumber",
       "schema": "string",
       "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "serial number"
+      },
+      "name": "serialNumber",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "software",
+      "displayName": {
+        "en": "Software"
+      },
+      "writable": true,
+      "schema": "string"
     },
     {
       "@type": "Property",

--- a/Ontology/Willow/Asset/Asset.json
+++ b/Ontology/Willow/Asset/Asset.json
@@ -7,9 +7,7 @@
   "description": {
     "en": "A physical entity which has value, a distinct identity, and is typically manufacturered as a product."
   },
-  "extends" : [
-
-  ],
+  "extends": [],
   "contents": [
     {
       "@type": "Relationship",
@@ -117,16 +115,6 @@
         "en": "served by"
       },
       "name": "servedBy"
-    },
-    {
-      "@type": "Property",
-      "name": "networkId",
-      "displayName": {
-        "en": "Network ID"
-      },
-      "writable": true,
-      "schema": "string",
-      "comment": "Reference of the network to which the asset belongs. A Customer has one or many Networks. Network is considered the top-level entity for binding rail twins."
     },
     {
       "@type": "Property",
@@ -285,56 +273,11 @@
     {
       "@type": "Property",
       "displayName": {
-        "en": "IP address"
-      },
-      "name": "IPAddress",
-      "schema": "string",
-      "writable": true
-    },
-    {
-      "@type": "Property",
-      "displayName": {
-        "en": "MAC address"
-      },
-      "name": "MACAddress",
-      "schema": "string",
-      "writable": true
-    },
-    {
-      "@type": "Property",
-      "displayName": {
-        "en": "model number"
-      },
-      "name": "modelNumber",
-      "schema": "string",
-      "writable": true
-    },
-    {
-      "@type": "Property",
-      "displayName": {
         "en": "physical tag number"
       },
       "name": "physicalTagNumber",
       "schema": "string",
       "writable": true
-    },
-    {
-      "@type": "Property",
-      "displayName": {
-        "en": "serial number"
-      },
-      "name": "serialNumber",
-      "schema": "string",
-      "writable": true
-    },
-    {
-      "@type": "Property",
-      "name": "software",
-      "displayName": {
-        "en": "Software"
-      },
-      "writable": true,
-      "schema": "string"
     },
     {
       "@type": "Property",
@@ -346,7 +289,10 @@
       "schema": "string"
     },
     {
-      "@type": ["Property", "Distance"],
+      "@type": [
+        "Property",
+        "Distance"
+      ],
       "name": "linearReferencePointLocation",
       "displayName": {
         "en": "Linear Reference Point Location"
@@ -357,7 +303,11 @@
       "comment": "Distance of a point from the start of a linear reference object"
     },
     {
-      "@type": ["Property", "ValueAnnotation", "Override"],
+      "@type": [
+        "Property",
+        "ValueAnnotation",
+        "Override"
+      ],
       "displayName": {
         "en": "linear reference point location unit"
       },

--- a/Ontology/Willow/Structure/Structure.json
+++ b/Ontology/Willow/Structure/Structure.json
@@ -7,9 +7,7 @@
   "description": {
     "en": "An entity which is constructed."
   },
-  "extends" : [
-
-  ],
+  "extends": [],
   "contents": [
     {
       "@type": "Relationship",
@@ -128,16 +126,6 @@
       },
       "name": "ownedBy",
       "target": "dtmi:com:willowinc:Agent;1"
-    },
-    {
-      "@type": "Property",
-      "name": "landId",
-      "displayName": {
-        "en": "Land ID"
-      },
-      "writable": true,
-      "schema": "string",
-      "comment": "Reference of the land (i.e. airport) to which the asset belongs. A Customer has one or many Lands. Land is considered the top-level entity for binding airport twins."
     },
     {
       "@type": "Property",
@@ -310,9 +298,69 @@
       },
       "writable": true,
       "schema": "string"
+    },
+    {
+      "@type": [
+        "Property",
+        "Distance"
+      ],
+      "name": "linearReferencePointLocation",
+      "displayName": {
+        "en": "Linear Reference Point Location"
+      },
+      "writable": true,
+      "schema": "double",
+      "unit": "metre",
+      "comment": "Distance of a point from the start of a linear reference object"
+    },
+    {
+      "@type": [
+        "Property",
+        "ValueAnnotation",
+        "Override"
+      ],
+      "displayName": {
+        "en": "linear reference point location unit"
+      },
+      "name": "linearReferencePointLocationUnit",
+      "annotates": "linearReferencePointLocation",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "linearReferenceLineLocation",
+      "displayName": {
+        "en": "Linear Reference Line Location"
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "start",
+            "displayName": {
+              "en": "Start"
+            },
+            "schema": "double"
+          },
+          {
+            "name": "end",
+            "displayName": {
+              "en": "End"
+            },
+            "schema": "double"
+          }
+        ]
+      },
+      "comment": "Start and end distances of a line from the start of a linear reference object"
     }
   ],
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }


### PR DESCRIPTION
We're treating assets and structures as one "type" in the application context. It'll be easier at this time to align their properties with one another.

This means removing a few properties that we aren't using and adding others that are being used.
**Asset**
- removed Network ID

**Structure**
- removed Land ID
- added Linear Reference Point and Line Locations